### PR TITLE
Fire event on unspiderfy

### DIFF
--- a/src/MarkerCluster.Spiderfier.js
+++ b/src/MarkerCluster.Spiderfier.js
@@ -112,6 +112,7 @@ L.MarkerCluster.include({
 			}
 		}
 
+		group.fire('unspiderfied');
 		group._spiderfied = null;
 	}
 });
@@ -341,6 +342,7 @@ L.MarkerCluster.include(!L.DomUtil.TRANSITION ? {
 				delete m._spiderLeg;
 			}
 			group._animationEnd();
+			group.fire('unspiderfied');
 		}, 200);
 	}
 });


### PR DESCRIPTION
When animating unspiderfy there is a timeout.  Fire event when done to let users know unspiderfy is complete.
